### PR TITLE
feat : [004] 관리자페이지 - 강사 정보 관리 페이지 구현 (pageable) + member테이블 category 컬럼 추가

### DIFF
--- a/src/main/java/com/samssak/lms/controller/AdminController.java
+++ b/src/main/java/com/samssak/lms/controller/AdminController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -28,6 +29,9 @@ public class AdminController {
   public String admin(final Pageable pageable, Model model,
       @RequestParam(defaultValue="null") String sortName) {
 
+    // 학생
+    String role = "student";
+
     // 정렬 파라미터 값
     String sort = "";
     if (sortName == null) {
@@ -43,7 +47,7 @@ public class AdminController {
     }
 
     // 데이터 가져오기
-    Page<Member> memberList = adminService.pagingMember(pageable);
+    Page<Member> memberList = adminService.pagingMember(role, pageable);
 
     // 1 페이지 ~ 마지막 페이지
     List<Integer> pageList = new ArrayList<>();
@@ -57,6 +61,58 @@ public class AdminController {
     model.addAttribute("pageList", pageList);
 
     return "/admin/admin_member";
+  }
+
+  // [회원 + 강사] 회원, 강사 정보 상세 페이지
+  @GetMapping("/admin/member/{email}")
+  public String memberDetail(@PathVariable String email, Model model) {
+
+    Member member = adminService.findMember(email);
+
+    model.addAttribute("member", member);
+
+
+    return "/admin/member_detail";
+  }
+
+
+  // [강사] 강사 정보 관리 목록 페이지
+  @GetMapping("/admin/teacher")
+  public String teacher(final Pageable pageable, Model model,
+      @RequestParam(defaultValue="null") String sortName) {
+
+    // 강사
+    String role = "teacher";
+
+    // 정렬 파라미터 값
+    String sort = "";
+    if (sortName == null) {
+
+    } else if (sortName.equals("old")) {
+      sort = "createDate,asc";
+    } else if (sortName.equals("new")) {
+      sort = "createDate,desc";
+    } else if (sortName.equals("nameAsc")) {
+      sort = "name,asc";
+    } else if (sortName.equals("nameDesc")) {
+      sort = "name,desc";
+    }
+
+    // 데이터 가져오기
+    Page<Member> memberList = adminService.pagingMember(role, pageable);
+
+    // 1 페이지 ~ 마지막 페이지
+    List<Integer> pageList = new ArrayList<>();
+    for (int i = 1; i <= memberList.getTotalPages(); i++) {
+      pageList.add(i);
+    }
+
+    model.addAttribute("memberList", memberList);
+    model.addAttribute("sortName", sortName);
+    model.addAttribute("sort", sort);
+    model.addAttribute("pageList", pageList);
+
+    return "/admin/admin_teacher";
   }
 
 }

--- a/src/main/java/com/samssak/lms/controller/MemberController.java
+++ b/src/main/java/com/samssak/lms/controller/MemberController.java
@@ -108,7 +108,7 @@ public class MemberController {
 
 
   // 로그아웃 시 - 세션 삭제
-  @GetMapping("/member/delSession")
+  @GetMapping("/member/del-session")
   public String delSession(HttpServletRequest request, HttpServletResponse response) {
 
     HttpSession session = request.getSession(false); // false: 세션이 없으면 새로 생성하지 않음

--- a/src/main/java/com/samssak/lms/entity/Member.java
+++ b/src/main/java/com/samssak/lms/entity/Member.java
@@ -27,7 +27,8 @@ public class Member {
   @Column(name = "create_date")
   private LocalDateTime createDate;
 
-  private String role;    // 123 : 관리자, teacher : 강사, student : 학생
+  private String role;    // admin : 관리자, teacher : 강사, student : 학생
+  private String category; // role이 teacher일 때만 작성 // 예시 ) 프론트엔드, 백엔드, 모바일앱개발, 알고리즘, 자격증
   private String active;  // 0 : 비활성화 , 1 : 활성화(이메일 인증시)
   private String active_key;  // 이메일 인증 키
   private String profile_image;

--- a/src/main/java/com/samssak/lms/repository/MemberRepository.java
+++ b/src/main/java/com/samssak/lms/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.samssak.lms.repository;
 
 import com.samssak.lms.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
@@ -9,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     boolean existsByEmail(String email);
 
     Member findByEmail(String email);
+
+    Page<Member> findByRole(String role, Pageable pageable);
 }

--- a/src/main/java/com/samssak/lms/service/AdminService.java
+++ b/src/main/java/com/samssak/lms/service/AdminService.java
@@ -6,7 +6,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface AdminService {
 
-  public Page<Member> pagingMember(Pageable pageable);
+  public Page<Member> pagingMember(String role, Pageable pageable);
 
-  public boolean pagingCourse();
+  // 회원 정보 조회
+  public Member findMember(String email);
+
 }

--- a/src/main/java/com/samssak/lms/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/samssak/lms/service/impl/AdminServiceImpl.java
@@ -15,16 +15,20 @@ public class AdminServiceImpl implements AdminService {
   private final MemberRepository memberRepository;
 
   @Override
-  public Page<Member> pagingMember(Pageable pageable) {
+  public Page<Member> pagingMember(String role, Pageable pageable) {
 
-    Page<Member> memberList = memberRepository.findAll(pageable);
+    Page<Member> memberList = memberRepository.findByRole(role, pageable);
 
     return memberList;
   }
 
   @Override
-  public boolean pagingCourse() {
+  public Member findMember(String email) {
 
-    return false;
+    Member member = memberRepository.findByEmail(email);
+
+    return member;
   }
+
+
 }

--- a/src/main/resources/templates/admin/admin_teacher.jsp
+++ b/src/main/resources/templates/admin/admin_teacher.jsp
@@ -46,6 +46,7 @@
         <div id="Sub840_conbody">
             <div id="Sub840_conbW">
 
+
                 <!-- 좌측 네비바 start -->
                 <div id="Sub840_Left">
 
@@ -249,14 +250,12 @@
 
                             <!--// cont -->
                             <div class="cont_tit_type1 cont_tit_type1_1">
-                                <strong class="tit">회원 정보 관리</strong>
+                                <strong class="tit">강사 정보 관리</strong>
 
                             </div>
 
 
                             <!-- cont//-->
-
-
 
                             <!-- 수강중 강좌 TAB -->
 
@@ -267,10 +266,16 @@
                             <div class="list_t_sort">
 
                                 <span class="wr_sort_btn">
-                                    <a href="/admin?sort=createDate,asc&sortName=old" th:classappend="${sortName == 'old'} ? 'btn_align on' : 'btn_align'">Old</a>
-                                    <a href="/admin?sort=createDate,desc&sortName=new" th:classappend="${sortName == 'new'} ? 'btn_align on' : 'btn_align'">New</a>
-                                    <a href="/admin?sort=name,asc&sortName=nameAsc" th:classappend="${sortName == 'nameAsc'} ? 'btn_align on' : 'btn_align'">이름 오름차순</a>
-                                    <a href="/admin?sort=name,desc&sortName=nameDesc" th:classappend="${sortName == 'nameDesc'} ? 'btn_align on' : 'btn_align'">이름 내림차순</a>
+                                    <a href="/admin/teacher?sort=createDate,asc&sortName=old"
+                                        th:classappend="${sortName == 'old'} ? 'btn_align on' : 'btn_align'">Old</a>
+                                    <a href="/admin/teacher?sort=createDate,desc&sortName=new"
+                                        th:classappend="${sortName == 'new'} ? 'btn_align on' : 'btn_align'">New</a>
+                                    <a href="/admin/teacher?sort=name,asc&sortName=nameAsc"
+                                        th:classappend="${sortName == 'nameAsc'} ? 'btn_align on' : 'btn_align'">이름
+                                        오름차순</a>
+                                    <a href="/admin/teacher?sort=name,desc&sortName=nameDesc"
+                                        th:classappend="${sortName == 'nameDesc'} ? 'btn_align on' : 'btn_align'">이름
+                                        내림차순</a>
                                 </span>
                             </div>
 
@@ -280,8 +285,9 @@
 
                                     <div class="wr_listcont">
 
-                                        <a th:href="@{'/admin/member/' + ${member.email}}" class="cont_tit"><span th:text="${member.name}"></span></a>
-                                        <!--2024-07-29-->
+                                        <a th:href="@{'/admin/member/' + ${member.email}}" class="cont_tit"><span
+                                                th:text="${member.name}"></span></a>
+
                                         <span>이메일 : </span><span th:text="${member.email}"></span>
                                         &nbsp;|&nbsp;
                                         <span>핸드폰 : </span><span th:text="${member.phone}"></span>
@@ -312,7 +318,7 @@
                             <div class="lect_paging mt_20">
                                 <span class="page">
                                     <span th:each="pageNum : ${pageList}">
-                                        <a th:href="@{/admin(page=${pageNum-1}, sortName=${sortName}, sort=${sort})}"
+                                        <a th:href="@{/admin/teacher(page=${pageNum-1}, sortName=${sortName}, sort=${sort})}"
                                             th:text="${pageNum}"
                                             th:class="${pageNum == memberList.getNumber + 1 ? 'active' : ''}"
                                             style="padding: 10px;">

--- a/src/main/resources/templates/admin/member_detail.jsp
+++ b/src/main/resources/templates/admin/member_detail.jsp
@@ -110,6 +110,8 @@
 
 
 
+
+
                 <div id="Sub840_con">
 
 
@@ -231,16 +233,6 @@
                     </div>
 
 
-
-
-
-                    <script type="text/javascript" src="/common/js_2013/etoos_default_new.js"></script>
-                    <script type="text/javascript" src="/common/js_2013/jquery.json-2.3.js"></script>
-                    <script type="text/javascript" src="/common/js_2013/jquery.form.js"></script>
-                    <script type="text/javascript" src="/common/js_2013/common_etoos.js"></script>
-
-
-
                     <!-- myroom 시작 -->
                     <div id="wrapmyroom">
                         <div class="wr_cont_f my_lectroom">
@@ -249,42 +241,29 @@
 
                             <!--// cont -->
                             <div class="cont_tit_type1 cont_tit_type1_1">
-                                <strong class="tit">회원 정보 관리</strong>
+                                <strong class="tit">회원/강사 정보 상세 페이지</strong>
 
                             </div>
 
 
                             <!-- cont//-->
 
-
-
                             <!-- 수강중 강좌 TAB -->
-
-
-
-                            <!-- 페이징 처리 -->
-
-                            <div class="list_t_sort">
-
-                                <span class="wr_sort_btn">
-                                    <a href="/admin?sort=createDate,asc&sortName=old" th:classappend="${sortName == 'old'} ? 'btn_align on' : 'btn_align'">Old</a>
-                                    <a href="/admin?sort=createDate,desc&sortName=new" th:classappend="${sortName == 'new'} ? 'btn_align on' : 'btn_align'">New</a>
-                                    <a href="/admin?sort=name,asc&sortName=nameAsc" th:classappend="${sortName == 'nameAsc'} ? 'btn_align on' : 'btn_align'">이름 오름차순</a>
-                                    <a href="/admin?sort=name,desc&sortName=nameDesc" th:classappend="${sortName == 'nameDesc'} ? 'btn_align on' : 'btn_align'">이름 내림차순</a>
-                                </span>
-                            </div>
 
                             <ul class="myroom_list5 list5_type2">
 
-                                <li th:each="member : ${memberList}" id="lectureStudyView_nor">
+                                <li th:each="member : ${member}" id="lectureStudyView_nor">
 
                                     <div class="wr_listcont">
 
-                                        <a th:href="@{'/admin/member/' + ${member.email}}" class="cont_tit"><span th:text="${member.name}"></span></a>
-                                        <!--2024-07-29-->
+                                        <span>이름 : </span><span th:text="${member.name}"></span>
+                                        <br>
                                         <span>이메일 : </span><span th:text="${member.email}"></span>
-                                        &nbsp;|&nbsp;
+                                        <br>
                                         <span>핸드폰 : </span><span th:text="${member.phone}"></span>
+                                        <br>
+                                        <span>학생/강사 : </span><span th:text="${member.role}"></span>
+                                        <br>
                                         <div class="cont_info">
                                             가입날짜 : <span class="mrf_num12 mrf_pb1"><span
                                                     th:text="${member.createDate}"></span></span>
@@ -295,34 +274,6 @@
                                 </li>
 
                             </ul>
-
-                            <!-- 페이징 넘버 -->
-                            <style>
-                                .active {
-                                    font-weight: bold;
-                                    color: green;
-                                }
-
-                                .page {
-                                    font-size: 30px;
-                                    font-weight: 400;
-                                }
-                            </style>
-
-                            <div class="lect_paging mt_20">
-                                <span class="page">
-                                    <span th:each="pageNum : ${pageList}">
-                                        <a th:href="@{/admin(page=${pageNum-1}, sortName=${sortName}, sort=${sort})}"
-                                            th:text="${pageNum}"
-                                            th:class="${pageNum == memberList.getNumber + 1 ? 'active' : ''}"
-                                            style="padding: 10px;">
-                                        </a>
-                                    </span>
-                                </span>
-                            </div>
-                            <!-- // 페이징 넘버 -->
-
-
 
                             <!-- cont//-->
 


### PR DESCRIPTION
# 변경사항
### AS-IS (문제사항)
- GET /admin : [관리자 페이지] 강사와 회원 정보가 같이 출력됨 
ㄴ 강사와 회원 정보 분리 필요
- member테이블 : 강사의 강의 과목 카테고리 컬럼 필요 

### TO-BE (해결)
[ 프론트 ]
- 관리자 페이지 : 회원 정보 상세 페이지 
- 관리자 페이지 : 강사 정보 관리 목록 페이지 
- 관리자 페이지 : 강사 정보 상세 페이지 

[ 백엔드 ]
- Member.class : 강사의 주요 강의 과목 카테고리(category) 컬럼 추가

- GET /admin/member/{email}
 ㄴ 관리자페이지 : 회원 정보 목록의 회원 이름 선택 시 회원 정보 상세페이지로 이동

- GET /admin/teacher 
ㄴ 1) 강사 정보 관리
  - 페이징 처리 : Pageable 사용
  - 한 page 당 20개씩 데이터를 노출
  - 정렬조건 : 등록 날짜 순 / 이름 순 정렬


<br>


# 테스트

### API 테스트
- 프론트 회면 테스트
  - 강사 정보 목록 페이지 정렬 , 페이징 확인 
  - 회원/강사 정보 상세 페이지 확인
 
[강사 정보 목록 페이지 정렬, 페이징]
![admin-teacher-old](https://github.com/user-attachments/assets/123b5186-72ad-4e7f-a94a-355623f7c758)


[회원/강사 정보 상세 페이지]
![회원,강사 정보 상세 페이지](https://github.com/user-attachments/assets/5f783ba3-b33a-47fc-b09f-4535dfa27105)
